### PR TITLE
perf(gas): `unchecked` loop in `getIgosDetails`

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,0 +1,5 @@
+IGOFactory_getIgosDetails_test:test_getIgosDetails_100_Results_default() (gas: 2329951)
+IGOFactory_getIgosDetails_test:test_getIgosDetails_200_Results() (gas: 4744690)
+IGOFactory_getIgosDetails_test:test_getIgosDetails_500_Results() (gas: 12341932)
+IGOFactory_getIgosDetails_test:test_getIgosDetails_5_Results() (gas: 155437)
+IGOFactory_getIgosDetails_test:test_getIgosDetails_From_50_to_149() (gas: 2329784)

--- a/src/IGOFactory.sol
+++ b/src/IGOFactory.sol
@@ -12,6 +12,8 @@ import {IGOStorage} from "./IGOStorage.sol";
 
 /// @dev Contract to deploy IGOs one the fly, in one transaction
 contract IGOFactory is Ownable, ReentrancyGuard {
+    uint256 public maxLoop = 100;
+
     struct IGODetail {
         string name;
         address igo;
@@ -90,16 +92,17 @@ contract IGOFactory is Ownable, ReentrancyGuard {
     {
         require(from <= to, "IGOFactory_INDEXES_REVERSED");
 
-        if (to > _igoDetails.length) to = _igoDetails.length;
-
         unchecked {
+            if ((to - from) > maxLoop) to = from + maxLoop;
+
             igos = new IGODetail[](to - from);
             for (uint256 i = from; i < to; ++i) {
                 igos[i - from] = _igoDetails[i];
             }
+            // loop end when i == to, but last call is _igoDetails[to - 1]
+            lastEvaludatedIndex = --to;
         }
 
-        lastEvaludatedIndex = to;
         totalItems = _igoDetails.length;
     }
 
@@ -123,5 +126,9 @@ contract IGOFactory is Ownable, ReentrancyGuard {
         );
         defaultVesting = newDefaultVesting;
         vestingCreationCode = newVestingCreationCode;
+    }
+
+    function setMaxLoop(uint256 newMaxLoop) external onlyOwner {
+        maxLoop = newMaxLoop;
     }
 }

--- a/src/IGOFactory.sol
+++ b/src/IGOFactory.sol
@@ -92,9 +92,11 @@ contract IGOFactory is Ownable, ReentrancyGuard {
 
         if (to > _igoDetails.length) to = _igoDetails.length;
 
-        igos = new IGODetail[](to - from);
-        for (uint256 i = from; i < to; ++i) {
-            igos[i - from] = _igoDetails[i];
+        unchecked {
+            igos = new IGODetail[](to - from);
+            for (uint256 i = from; i < to; ++i) {
+                igos[i - from] = _igoDetails[i];
+            }
         }
 
         lastEvaludatedIndex = to;

--- a/test/foundry/IGOFactory.getIgosDetails.t.sol
+++ b/test/foundry/IGOFactory.getIgosDetails.t.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.17;
+
+import "forge-std/Test.sol";
+
+import {Strings} from "openzeppelin-contracts/utils/Strings.sol";
+
+import {IGOFactory} from "../../src/IGOFactory.sol";
+import {IGOStorage} from "../../src/IGOStorage.sol";
+
+contract IGOFactory_Mock is IGOFactory {
+    function setIgoDetails(IGODetail[] memory igoDetails_) public {
+        _igoDetails = igoDetails_;
+    }
+}
+
+contract IGOFactory_getIgosDetails_test is Test {
+    IGOFactory_Mock public factory;
+
+    address public paymentToken = makeAddr("paymentToken");
+    address public permit2 = makeAddr("permit2");
+
+    uint256 public totalItems = 500;
+    uint256 public maxLoop;
+
+    function setUp() public {
+        factory = new IGOFactory_Mock();
+        factory.setIgoDetails(_generateIgoDetails(totalItems));
+    }
+
+    //////////////// DEFAULT LOOP ////////////////
+    function test_getIgosDetails_100_Results_default() public {
+        (, uint256 lastEvaludatedIndex, uint256 totalItems_) = factory
+            .getIgosDetails(0, totalItems);
+
+        assertEq(lastEvaludatedIndex, factory.maxLoop() - 1);
+        assertEq(totalItems_, totalItems);
+    }
+
+    function test_getIgosDetails_From_50_to_149() public {
+        uint256 from = 50;
+
+        (, uint256 lastEvaludatedIndex, uint256 totalItems_) = factory
+            .getIgosDetails(from, totalItems);
+
+        assertEq(lastEvaludatedIndex, (from + factory.maxLoop()) - 1);
+        assertEq(totalItems_, totalItems);
+    }
+
+    //////////////// GAS TESTS ////////////////
+    function test_getIgosDetails_5_Results() public {
+        maxLoop = 5;
+        factory.setMaxLoop(maxLoop);
+
+        (, uint256 lastEvaludatedIndex, uint256 totalItems_) = factory
+            .getIgosDetails(0, totalItems);
+
+        assertEq(lastEvaludatedIndex, --maxLoop);
+        assertEq(totalItems_, totalItems);
+    }
+
+    function test_getIgosDetails_200_Results() public {
+        maxLoop = 200;
+        factory.setMaxLoop(maxLoop);
+
+        (, uint256 lastEvaludatedIndex, uint256 totalItems_) = factory
+            .getIgosDetails(0, totalItems);
+
+        assertEq(lastEvaludatedIndex, --maxLoop);
+        assertEq(totalItems_, totalItems);
+    }
+
+    function test_getIgosDetails_500_Results() public {
+        maxLoop = 500;
+        factory.setMaxLoop(maxLoop);
+
+        (, uint256 lastEvaludatedIndex, uint256 totalItems_) = factory
+            .getIgosDetails(0, totalItems);
+
+        assertEq(lastEvaludatedIndex, --maxLoop);
+        assertEq(totalItems_, totalItems);
+    }
+
+    function _generateIgoDetails(
+        uint256 amount
+    ) internal returns (IGOFactory.IGODetail[] memory generatedIgoDetails) {
+        generatedIgoDetails = new IGOFactory.IGODetail[](amount);
+        address igo;
+        address vesting;
+
+        for (uint256 i = 0; i < amount; i++) {
+            igo = makeAddr(string.concat("igo", Strings.toString(i)));
+            vesting = makeAddr(string.concat("vesting", Strings.toString(i)));
+
+            generatedIgoDetails[i] = IGOFactory.IGODetail(
+                string.concat("name-", Strings.toString(i)),
+                igo,
+                vesting,
+                IGOStorage.SetUp(
+                    vesting,
+                    paymentToken,
+                    permit2,
+                    10_000_000 ether,
+                    0 ether,
+                    2
+                )
+            );
+        }
+    }
+}

--- a/test/foundry/IGOFactory.t.sol
+++ b/test/foundry/IGOFactory.t.sol
@@ -79,7 +79,7 @@ contract IGOFactory_test is Test, ISharedInternal {
         ) = factory.getIgosDetails(0, 1);
 
         assertEq(totalItems, 1);
-        assertEq(lastEvaludatedIndex, 1);
+        assertEq(lastEvaludatedIndex, 0);
         assertEq(igos[0].name, "test");
     }
 


### PR DESCRIPTION
replace #50 (closed due to renaming)

maybe it can be optimised further using YUL

Now as you can see in .gas-snapshot should cost around **2,329,951** gas for **100** elements

This a lot but enough for data for frontend to index IGOs